### PR TITLE
flattened the trie object returned by create() with JSON.parse/stringify

### DIFF
--- a/test/create.js
+++ b/test/create.js
@@ -3,7 +3,7 @@ const { create } = require('../trie');
 const sampleDictionary = require('./sample-dictionary');
 const sampleTrie = require('./sample-trie');
 
-const trie = create(sampleDictionary);
+const trie = JSON.parse(JSON.stringify(create(sampleDictionary)));
 
 console.log( JSON.stringify(trie, null, 2) );
 


### PR DESCRIPTION
There was an issue with the create.js test that if the create() in trie.js returned a trie object, it would fail assertion even if properly formed because it was not a simple string.  The trie obj returned need to be flattened to pass assertions.